### PR TITLE
feat: Add browser-style repository tabs

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -89,6 +89,12 @@ export interface IAppState {
   readonly recentRepositories: ReadonlyArray<number>
 
   /**
+   * Open repository tabs (browser-style), ordered left-to-right. Repository ids
+   * must still exist in {@link repositories}.
+   */
+  readonly openRepositoryTabIDs: ReadonlyArray<number>
+
+  /**
    * A cache of the latest repository state values, keyed by the repository id
    */
   readonly localRepositoryStateLookup: Map<number, ILocalRepositoryState>

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -229,6 +229,11 @@ import { TypedBaseStore } from './base-store'
 import { MergeTreeResult } from '../../models/merge'
 import { promiseWithMinimumTimeout } from '../promise'
 import { BackgroundFetcher } from './helpers/background-fetcher'
+import {
+  cleanupOpenRepositoryTabIDs,
+  loadOpenRepositoryTabIDs,
+  saveOpenRepositoryTabIDs,
+} from './helpers/open-repository-tabs-storage'
 import { RepositoryStateCache } from './repository-state-cache'
 import { readEmoji } from '../read-emoji'
 import { Emoji } from '../emoji'
@@ -481,6 +486,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private accounts: ReadonlyArray<Account> = new Array<Account>()
   private repositories: ReadonlyArray<Repository> = new Array<Repository>()
   private recentRepositories: ReadonlyArray<number> = new Array<number>()
+  private openRepositoryTabIDs: ReadonlyArray<number> = new Array<number>()
 
   private selectedRepository: Repository | CloningRepository | null = null
 
@@ -930,6 +936,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.repositoriesStore.onDidUpdate(updateRepositories => {
       this.repositories = updateRepositories
+      this.cleanupOpenRepositoryTabs(false)
       this.updateRepositorySelectionAfterRepositoriesChanged()
       this.emitUpdate()
     })
@@ -1053,6 +1060,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       accounts: this.accounts,
       repositories,
       recentRepositories: this.recentRepositories,
+      openRepositoryTabIDs: this.openRepositoryTabIDs,
       localRepositoryStateLookup: this.localRepositoryStateLookup,
       windowState: this.windowState,
       windowZoomFactor: this.windowZoomFactor,
@@ -1915,6 +1923,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.selectedRepository = repository
 
+    if (repository instanceof Repository) {
+      this.ensureRepositoryTab(repository.id)
+    }
+
     this.emitUpdate()
     this.stopBackgroundFetching()
     this.stopPullRequestUpdater()
@@ -2204,6 +2216,21 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.accounts = accounts
     this.repositories = repositories
+
+    this.openRepositoryTabIDs = cleanupOpenRepositoryTabIDs(
+      loadOpenRepositoryTabIDs(),
+      this.repositories
+    )
+    if (this.openRepositoryTabIDs.length === 0) {
+      const lastSelectedID = getNumber(LastSelectedRepositoryIDKey, 0)
+      if (lastSelectedID > 0) {
+        const exists = this.repositories.some(r => r.id === lastSelectedID)
+        if (exists) {
+          this.openRepositoryTabIDs = [lastSelectedID]
+          saveOpenRepositoryTabIDs(this.openRepositoryTabIDs)
+        }
+      }
+    }
 
     this.updateRepositorySelectionAfterRepositoriesChanged()
 
@@ -8653,6 +8680,154 @@ export class AppStore extends TypedBaseStore<IAppState> {
     setBoolean(showChangesFilterKey, this.showChangesFilter)
     this.updateMenuLabelsForSelectedRepository()
     this.emitUpdate()
+  }
+
+  private cleanupOpenRepositoryTabs(emitUpdate: boolean = true) {
+    const next = cleanupOpenRepositoryTabIDs(
+      this.openRepositoryTabIDs,
+      this.repositories
+    )
+
+    if (next.length === this.openRepositoryTabIDs.length) {
+      return
+    }
+
+    this.openRepositoryTabIDs = next
+    saveOpenRepositoryTabIDs(this.openRepositoryTabIDs)
+
+    if (emitUpdate) {
+      this.emitUpdate()
+    }
+  }
+
+  private ensureRepositoryTab(repositoryId: number) {
+    if (this.openRepositoryTabIDs.includes(repositoryId)) {
+      return
+    }
+
+    this.openRepositoryTabIDs = [...this.openRepositoryTabIDs, repositoryId]
+    saveOpenRepositoryTabIDs(this.openRepositoryTabIDs)
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _closeRepositoryTab(repositoryId: number): Promise<void> {
+    const idx = this.openRepositoryTabIDs.indexOf(repositoryId)
+    if (idx === -1) {
+      return
+    }
+
+    const nextTabs = [...this.openRepositoryTabIDs]
+    nextTabs.splice(idx, 1)
+    this.openRepositoryTabIDs = nextTabs
+    saveOpenRepositoryTabIDs(this.openRepositoryTabIDs)
+
+    const wasSelected = this.selectedRepository?.id === repositoryId
+    if (wasSelected) {
+      if (nextTabs.length === 0) {
+        await this._selectRepository(null)
+      } else {
+        const newIndex = idx === 0 ? 0 : idx - 1
+        const nextId = nextTabs[newIndex]
+        const repo = this.repositories.find(r => r.id === nextId) ?? null
+        if (repo !== null) {
+          await this._selectRepository(repo)
+        } else {
+          await this._selectRepository(null)
+        }
+      }
+    } else {
+      this.emitUpdate()
+    }
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _closeOtherRepositoryTabs(repositoryId: number): Promise<void> {
+    if (!this.openRepositoryTabIDs.includes(repositoryId)) {
+      return
+    }
+
+    this.openRepositoryTabIDs = [repositoryId]
+    saveOpenRepositoryTabIDs(this.openRepositoryTabIDs)
+
+    const repo = this.repositories.find(r => r.id === repositoryId) ?? null
+    if (repo !== null) {
+      await this._selectRepository(repo)
+    } else {
+      this.emitUpdate()
+    }
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _closeRepositoryTabsToRight(
+    repositoryId: number
+  ): Promise<void> {
+    const idx = this.openRepositoryTabIDs.indexOf(repositoryId)
+    if (idx === -1) {
+      return
+    }
+
+    const nextTabs = this.openRepositoryTabIDs.slice(0, idx + 1)
+    this.openRepositoryTabIDs = nextTabs
+    saveOpenRepositoryTabIDs(this.openRepositoryTabIDs)
+
+    const selectedId = this.selectedRepository?.id
+    if (
+      selectedId !== undefined &&
+      selectedId !== null &&
+      !nextTabs.includes(selectedId)
+    ) {
+      const repo = this.repositories.find(r => r.id === repositoryId) ?? null
+      if (repo !== null) {
+        await this._selectRepository(repo)
+      } else {
+        this.emitUpdate()
+      }
+    } else {
+      this.emitUpdate()
+    }
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _selectAdjacentRepositoryTab(
+    direction: 'next' | 'previous'
+  ): Promise<void> {
+    const tabs = this.openRepositoryTabIDs
+    if (tabs.length === 0) {
+      return
+    }
+
+    const selectedId = this.selectedRepository?.id
+    let currentIndex = selectedId !== undefined ? tabs.indexOf(selectedId) : -1
+
+    if (currentIndex === -1) {
+      currentIndex = direction === 'next' ? -1 : 0
+    }
+
+    const delta = direction === 'next' ? 1 : -1
+    const nextIndex = (currentIndex + delta + tabs.length) % tabs.length
+    const nextId = tabs[nextIndex]
+    const repo = this.repositories.find(r => r.id === nextId) ?? null
+    if (repo !== null) {
+      await this._selectRepository(repo)
+    }
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public _reorderRepositoryTabs(
+    orderedRepositoryIds: ReadonlyArray<number>
+  ): Promise<void> {
+    const current = new Set(this.openRepositoryTabIDs)
+    if (
+      orderedRepositoryIds.length !== current.size ||
+      !orderedRepositoryIds.every(id => current.has(id))
+    ) {
+      return Promise.resolve()
+    }
+
+    this.openRepositoryTabIDs = [...orderedRepositoryIds]
+    saveOpenRepositoryTabIDs(this.openRepositoryTabIDs)
+    this.emitUpdate()
+    return Promise.resolve()
   }
 }
 

--- a/app/src/lib/stores/helpers/open-repository-tabs-storage.ts
+++ b/app/src/lib/stores/helpers/open-repository-tabs-storage.ts
@@ -1,0 +1,22 @@
+import { getNumberArray, setNumberArray } from '../../local-storage'
+import { Repository } from '../../../models/repository'
+
+export const OpenRepositoryTabsKey = 'open-repository-tab-ids'
+
+export function loadOpenRepositoryTabIDs(): ReadonlyArray<number> {
+  return getNumberArray(OpenRepositoryTabsKey)
+}
+
+export function saveOpenRepositoryTabIDs(
+  repositoryIds: ReadonlyArray<number>
+): void {
+  setNumberArray(OpenRepositoryTabsKey, repositoryIds)
+}
+
+export function cleanupOpenRepositoryTabIDs(
+  openTabIds: ReadonlyArray<number>,
+  repositories: ReadonlyArray<Repository>
+): ReadonlyArray<number> {
+  const validIds = new Set(repositories.map(r => r.id))
+  return openTabIds.filter(id => validIds.has(id))
+}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -44,6 +44,7 @@ import { CloningRepository } from '../models/cloning-repository'
 import { TitleBar, ZoomInfo, FullScreenInfo } from './window'
 
 import { RepositoriesList } from './repositories-list'
+import { RepositoryTabs } from './repository-tabs/repository-tabs'
 import { RepositoryView } from './repository'
 import { RenameBranch } from './rename-branch'
 import { DeleteBranch, DeleteRemoteBranch } from './delete-branch'
@@ -352,8 +353,48 @@ export class App extends React.Component<IAppProps, IAppState> {
   public componentWillUnmount() {
     window.clearInterval(this.updateIntervalHandle)
 
+    window.removeEventListener('keydown', this.onRepositoryTabNavigationKeyDown)
+
     if (__DARWIN__) {
       window.removeEventListener('keydown', this.onMacOSWindowKeyDown)
+    }
+  }
+
+  /**
+   * Switch repository tabs with ⌥⌘←/→ (macOS) or Ctrl+Alt+←/→ (Windows/Linux).
+   */
+  private onRepositoryTabNavigationKeyDown = (event: KeyboardEvent) => {
+    if (event.defaultPrevented) {
+      return
+    }
+
+    if (this.isShowingModal) {
+      return
+    }
+
+    if (this.state.openRepositoryTabIDs.length === 0) {
+      return
+    }
+
+    const modifier =
+      __DARWIN__ &&
+      event.metaKey &&
+      event.altKey &&
+      !event.ctrlKey &&
+      !event.shiftKey
+        ? true
+        : !__DARWIN__ && event.ctrlKey && event.altKey && !event.shiftKey
+
+    if (!modifier) {
+      return
+    }
+
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault()
+      this.props.dispatcher.selectAdjacentRepositoryTab('previous')
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault()
+      this.props.dispatcher.selectAdjacentRepositoryTab('next')
     }
   }
 
@@ -1024,6 +1065,8 @@ export class App extends React.Component<IAppProps, IAppState> {
     document.addEventListener('focus', this.onDocumentFocus, {
       capture: true,
     })
+
+    window.addEventListener('keydown', this.onRepositoryTabNavigationKeyDown)
   }
 
   private onDocumentFocus = (event: FocusEvent) => {
@@ -2905,11 +2948,41 @@ export class App extends React.Component<IAppProps, IAppState> {
         className={this.getDesktopAppContentsClassNames()}
       >
         {this.renderToolbar()}
+        {this.renderRepositoryTabs()}
         {this.renderBanner()}
         {this.renderRepository()}
         {this.renderPopups()}
         {this.renderDragElement()}
       </div>
+    )
+  }
+
+  private renderRepositoryTabs() {
+    if (this.state.showWelcomeFlow || this.inNoRepositoriesViewState()) {
+      return null
+    }
+
+    const selectedRepository =
+      this.state.selectedState?.type === SelectionType.Repository
+        ? this.state.selectedState.repository
+        : null
+
+    const repositories = this.state.repositories.filter(
+      (r): r is Repository => r instanceof Repository
+    )
+
+    if (repositories.length === 0) {
+      return null
+    }
+
+    return (
+      <RepositoryTabs
+        openRepositoryTabIDs={this.state.openRepositoryTabIDs}
+        repositories={repositories}
+        selectedRepository={selectedRepository}
+        localRepositoryStateLookup={this.state.localRepositoryStateLookup}
+        dispatcher={this.props.dispatcher}
+      />
     )
   }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -293,6 +293,30 @@ export class Dispatcher {
     return this.appStore._selectRepository(repository)
   }
 
+  public closeRepositoryTab(repositoryId: number): Promise<void> {
+    return this.appStore._closeRepositoryTab(repositoryId)
+  }
+
+  public closeOtherRepositoryTabs(repositoryId: number): Promise<void> {
+    return this.appStore._closeOtherRepositoryTabs(repositoryId)
+  }
+
+  public closeRepositoryTabsToRight(repositoryId: number): Promise<void> {
+    return this.appStore._closeRepositoryTabsToRight(repositoryId)
+  }
+
+  public selectAdjacentRepositoryTab(
+    direction: 'next' | 'previous'
+  ): Promise<void> {
+    return this.appStore._selectAdjacentRepositoryTab(direction)
+  }
+
+  public reorderRepositoryTabs(
+    orderedRepositoryIds: ReadonlyArray<number>
+  ): Promise<void> {
+    return this.appStore._reorderRepositoryTabs(orderedRepositoryIds)
+  }
+
   /** Change the selected section in the repository. */
   public changeRepositorySection(
     repository: Repository,

--- a/app/src/ui/repository-tabs/repository-tabs.tsx
+++ b/app/src/ui/repository-tabs/repository-tabs.tsx
@@ -1,0 +1,214 @@
+import * as React from 'react'
+import classNames from 'classnames'
+import { ILocalRepositoryState, Repository } from '../../models/repository'
+import { Dispatcher } from '../dispatcher'
+import { Octicon } from '../octicons'
+import * as octicons from '../octicons/octicons.generated'
+import { IMenuItem, showContextualMenu } from '../../lib/menu-item'
+import { FoldoutType } from '../../lib/app-state'
+
+const tabDragType = 'application/x-github-desktop-repository-tab'
+
+interface IRepositoryTabsProps {
+  readonly openRepositoryTabIDs: ReadonlyArray<number>
+  readonly repositories: ReadonlyArray<Repository>
+  readonly selectedRepository: Repository | null
+  readonly localRepositoryStateLookup: Map<number, ILocalRepositoryState>
+  readonly dispatcher: Dispatcher
+}
+
+interface IRepositoryTabsState {
+  readonly dragOverTabId: number | null
+}
+
+export class RepositoryTabs extends React.Component<
+  IRepositoryTabsProps,
+  IRepositoryTabsState
+> {
+  public constructor(props: IRepositoryTabsProps) {
+    super(props)
+    this.state = { dragOverTabId: null }
+  }
+
+  private onTabClick = (repositoryId: number) => {
+    const repo = this.props.repositories.find(r => r.id === repositoryId)
+    if (repo !== undefined) {
+      this.props.dispatcher.selectRepository(repo)
+    }
+  }
+
+  private onCloseClick = (
+    event: React.MouseEvent<HTMLButtonElement>,
+    repositoryId: number
+  ) => {
+    event.stopPropagation()
+    this.props.dispatcher.closeRepositoryTab(repositoryId)
+  }
+
+  private onOpenAnotherRepository = () => {
+    this.props.dispatcher.showFoldout({ type: FoldoutType.Repository })
+  }
+
+  private onTabContextMenu = (
+    event: React.MouseEvent,
+    repositoryId: number
+  ) => {
+    event.preventDefault()
+
+    const items: ReadonlyArray<IMenuItem> = [
+      {
+        label: 'Close Tab',
+        action: () => {
+          this.props.dispatcher.closeRepositoryTab(repositoryId)
+        },
+      },
+      {
+        label: 'Close Other Tabs',
+        action: () => {
+          this.props.dispatcher.closeOtherRepositoryTabs(repositoryId)
+        },
+      },
+      {
+        label: 'Close Tabs to the Right',
+        action: () => {
+          this.props.dispatcher.closeRepositoryTabsToRight(repositoryId)
+        },
+      },
+    ]
+
+    showContextualMenu(items)
+  }
+
+  private onTabDragStart =
+    (repositoryId: number) => (event: React.DragEvent) => {
+      event.dataTransfer.setData(tabDragType, String(repositoryId))
+      event.dataTransfer.effectAllowed = 'move'
+    }
+
+  private onTabDragOver = (repositoryId: number) => (event: React.DragEvent) => {
+    const types = Array.from(event.dataTransfer.types)
+    if (!types.includes(tabDragType)) {
+      return
+    }
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+    if (this.state.dragOverTabId !== repositoryId) {
+      this.setState({ dragOverTabId: repositoryId })
+    }
+  }
+
+  private onTabDrop =
+    (targetRepositoryId: number) => (event: React.DragEvent) => {
+      event.preventDefault()
+      this.setState({ dragOverTabId: null })
+      const raw = event.dataTransfer.getData(tabDragType)
+      const dragId = parseInt(raw, 10)
+      if (Number.isNaN(dragId) || dragId === targetRepositoryId) {
+        return
+      }
+
+      const ids = [...this.props.openRepositoryTabIDs]
+      const from = ids.indexOf(dragId)
+      const to = ids.indexOf(targetRepositoryId)
+      if (from === -1 || to === -1) {
+        return
+      }
+
+      const next = [...ids]
+      const [removed] = next.splice(from, 1)
+      next.splice(to, 0, removed)
+      void this.props.dispatcher.reorderRepositoryTabs(next)
+    }
+
+  private onTabStripDragEnd = () => {
+    this.setState({ dragOverTabId: null })
+  }
+
+  public render() {
+    const {
+      openRepositoryTabIDs,
+      repositories,
+      selectedRepository,
+      localRepositoryStateLookup,
+    } = this.props
+
+    return (
+      <div className="repository-tabs" role="presentation">
+        <div
+          className="repository-tabs-scroll"
+          role="tablist"
+          aria-label="Open repositories"
+          onDragEnd={this.onTabStripDragEnd}
+        >
+          {openRepositoryTabIDs.map(repositoryId => {
+            const repository = repositories.find(r => r.id === repositoryId)
+            if (repository === undefined) {
+              return null
+            }
+
+            const title =
+              repository.alias != null ? repository.alias : repository.name
+            const selected = selectedRepository?.id === repositoryId
+            const localState = localRepositoryStateLookup.get(repositoryId)
+            const ab = localState?.aheadBehind
+            const hasLocalChanges =
+              (localState?.changedFilesCount ?? 0) > 0 ||
+              (ab != null && (ab.ahead > 0 || ab.behind > 0))
+
+            const dropHighlight = this.state.dragOverTabId === repositoryId
+
+            return (
+              <div
+                key={repositoryId}
+                className={classNames('repository-tab', {
+                  selected,
+                  'drop-target': dropHighlight,
+                })}
+                role="presentation"
+                onContextMenu={e => this.onTabContextMenu(e, repositoryId)}
+                onDragOver={this.onTabDragOver(repositoryId)}
+                onDrop={this.onTabDrop(repositoryId)}
+              >
+                <button
+                  type="button"
+                  className="repository-tab-button"
+                  role="tab"
+                  aria-selected={selected}
+                  tabIndex={selected ? 0 : -1}
+                  draggable
+                  onDragStart={this.onTabDragStart(repositoryId)}
+                  onClick={() => this.onTabClick(repositoryId)}
+                >
+                  {hasLocalChanges ? (
+                    <span
+                      className="repository-tab-dirty"
+                      title="Uncommitted or unpushed changes"
+                    />
+                  ) : null}
+                  <span className="repository-tab-label">{title}</span>
+                </button>
+                <button
+                  type="button"
+                  className="repository-tab-close"
+                  aria-label={`Close ${title}`}
+                  onClick={e => this.onCloseClick(e, repositoryId)}
+                >
+                  <Octicon symbol={octicons.x} />
+                </button>
+              </div>
+            )
+          })}
+        </div>
+        <button
+          type="button"
+          className="repository-tabs-add"
+          title="Open another repository…"
+          aria-label="Open another repository"
+          onClick={this.onOpenAnotherRepository}
+        >
+          <Octicon symbol={octicons.plus} />
+        </button>
+      </div>
+    )
+  }
+}

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -12,6 +12,7 @@
 @import 'ui/list';
 @import 'ui/list-item-insertion-overlay';
 @import 'ui/repository-list';
+@import 'ui/repository-tabs';
 @import 'ui/changes';
 @import 'ui/cloning-repository-view';
 @import 'ui/diff';

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -331,6 +331,11 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --list-item-selected-active-badge-background-color: #{$white};
   --list-item-hover-background-color: #{$gray-100};
 
+  /**
+   * Repository picker foldout (toolbar): align with main chrome background.
+   */
+  --repository-sidebar-background: var(--background-color);
+
   /** Windows/Linux have custom scrollbars, see _scroll.scss */
   --win32-scroll-bar-size: 10px;
   --linux-scroll-bar-size: 10px;

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -264,6 +264,12 @@ body.theme-dark {
   --list-item-hover-background-color: #{$gray-800};
 
   /**
+   * Repository picker foldout: same plane as the toolbar so the panel
+   * does not read as a bright card on top of dark chrome.
+   */
+  --repository-sidebar-background: var(--toolbar-background-color);
+
+  /**
    * Toast notifications are shown temporarily for things like the zoom
    * percentage changing or the app toggling between full screen and normal
    * window mode.

--- a/app/styles/ui/_repository-tabs.scss
+++ b/app/styles/ui/_repository-tabs.scss
@@ -1,0 +1,207 @@
+.repository-tabs {
+  display: flex;
+  flex-direction: row;
+  flex-shrink: 0;
+  align-items: flex-end;
+  min-height: 40px;
+  padding: 0 var(--spacing-half);
+  padding-top: 6px;
+  gap: 2px;
+  border-bottom: 1px solid var(--box-border-color);
+  background: var(--repository-sidebar-background, var(--box-alt-background-color));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    0 1px 0 rgba(0, 0, 0, 0.12);
+
+  .repository-tabs-scroll {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    flex: 1;
+    min-width: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: thin;
+    align-items: flex-end;
+    gap: 4px;
+    padding-bottom: 0;
+  }
+
+  .repository-tab {
+    position: relative;
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+    flex-shrink: 0;
+    max-width: 260px;
+    min-height: 34px;
+    margin-bottom: -1px;
+    border: 1px solid transparent;
+    border-bottom: none;
+    border-radius: 8px 8px 0 0;
+    background: transparent;
+    transition:
+      background-color 0.15s ease,
+      border-color 0.15s ease,
+      box-shadow 0.15s ease;
+
+    &:hover:not(.selected) {
+      background: var(--list-item-hover-background-color);
+      border-color: var(--box-border-color);
+    }
+
+    &.selected {
+      background: var(--background-color);
+      border-color: var(--box-border-color);
+      box-shadow:
+        0 -1px 0 rgba(0, 0, 0, 0.06),
+        0 1px 2px rgba(0, 0, 0, 0.06);
+      z-index: 1;
+
+      &::after {
+        content: '';
+        position: absolute;
+        left: 10px;
+        right: 36px;
+        bottom: 0;
+        height: 2px;
+        border-radius: 2px 2px 0 0;
+        background: var(--accent-color);
+      }
+    }
+
+    &.drop-target {
+      background: var(--list-item-hover-background-color);
+      border-color: var(--accent-color);
+      box-shadow: inset 0 0 0 1px var(--accent-color);
+    }
+  }
+
+  .repository-tab-button {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex: 1;
+    min-width: 0;
+    padding: 8px 6px 8px 10px;
+    border: none;
+    background: transparent;
+    color: var(--text-color);
+    cursor: grab;
+    text-align: left;
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium, 500);
+    letter-spacing: 0.01em;
+
+    &:active {
+      cursor: grabbing;
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--focus-color);
+      outline-offset: -2px;
+      border-radius: 6px 0 0 0;
+    }
+  }
+
+  .repository-tab-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .repository-tab-dirty {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--color-changed);
+    margin-right: 8px;
+    flex-shrink: 0;
+    box-shadow:
+      0 0 0 1px rgba(0, 0, 0, 0.2),
+      0 0 6px rgba(0, 0, 0, 0.15);
+  }
+
+  .repository-tab-close {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    align-self: stretch;
+    border: none;
+    background: transparent;
+    padding: 0;
+    color: var(--text-secondary-color);
+    border-radius: 0 7px 0 0;
+    transition:
+      background-color 0.12s ease,
+      color 0.12s ease;
+
+    &:hover {
+      color: var(--text-color);
+      background: var(--list-item-hover-background-color);
+    }
+
+    .octicon {
+      width: 12px;
+      height: 12px;
+    }
+  }
+
+  .repository-tabs-add {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    align-self: center;
+    min-width: 36px;
+    height: 32px;
+    margin-bottom: 4px;
+    margin-left: 2px;
+    padding: 0 10px;
+    border: 1px solid var(--box-border-color);
+    border-radius: 8px;
+    background: var(--box-alt-background-color);
+    color: var(--text-secondary-color);
+    cursor: pointer;
+    transition:
+      background-color 0.15s ease,
+      color 0.15s ease,
+      border-color 0.15s ease,
+      box-shadow 0.15s ease;
+
+    &:hover {
+      color: var(--text-color);
+      background: var(--list-item-hover-background-color);
+      border-color: var(--box-border-contrast-color);
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--focus-color);
+      outline-offset: 2px;
+    }
+
+    .octicon {
+      width: 16px;
+      height: 16px;
+    }
+  }
+}
+
+body.theme-dark .repository-tabs {
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    0 1px 0 rgba(0, 0, 0, 0.35);
+
+  .repository-tab.selected {
+    box-shadow:
+      0 -1px 0 rgba(0, 0, 0, 0.35),
+      0 2px 8px rgba(0, 0, 0, 0.35);
+  }
+
+  .repository-tabs-add:hover {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+  }
+}

--- a/app/test/unit/open-repository-tabs-storage-test.ts
+++ b/app/test/unit/open-repository-tabs-storage-test.ts
@@ -1,0 +1,20 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import {
+  cleanupOpenRepositoryTabIDs,
+  loadOpenRepositoryTabIDs,
+  saveOpenRepositoryTabIDs,
+} from '../../src/lib/stores/helpers/open-repository-tabs-storage'
+import { Repository } from '../../src/models/repository'
+
+describe('open repository tabs storage', () => {
+  it('round-trips tab ids through localStorage', () => {
+    saveOpenRepositoryTabIDs([3, 1, 2])
+    assert.deepEqual(loadOpenRepositoryTabIDs(), [3, 1, 2])
+  })
+
+  it('filters tab ids to repositories that still exist', () => {
+    const repos = [new Repository('/a', 1, null, false)]
+    assert.deepEqual(cleanupOpenRepositoryTabIDs([1, 2, 3], repos), [1])
+  })
+})


### PR DESCRIPTION
## Summary

Adds a persistent tab bar above the main content area, similar to browser tabs:

- Each time you switch to a repository it opens as a tab, persisting across restarts.
- Tabs show the repo name and a dirty indicator (uncommitted/unpushed changes).
- **Close** individual tabs via the × button or the right-click context menu (Close Tab, Close Other Tabs, Close Tabs to the Right).
- **Reorder** tabs via drag-and-drop on the tab strip.
- **Keyboard navigation**: ⌥⌘← / ⌥⌘→ (macOS) or Ctrl+Alt+← / Ctrl+Alt+→ (Windows/Linux) to cycle through open tabs.
- A **+** button at the right opens the repository picker to add another repository tab.
- Tab state is persisted in `localStorage` via `open-repository-tabs-storage.ts`.

## Test plan

- [ ] Switch to several repositories — each opens as a tab.
- [ ] Restart the app — previously open tabs are restored.
- [ ] Close a tab — the next/previous tab is selected automatically.
- [ ] Drag a tab to reorder — position persists after restart.
- [ ] Right-click a tab → Close Other Tabs — only that tab remains.
- [ ] Use ⌥⌘← / ⌥⌘→ to cycle through tabs.
- [ ] Click **+** — the repository picker opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)