### PR TITLE
Fix repository tab persistence, ordering, and accessibility

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2699,11 +2699,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
     ) {
       const lastSelectedID = getNumber(LastSelectedRepositoryIDKey, 0)
       const fallbackTabIndex =
-        removedTabIndex === null
+        removedTabIndex === null || removedTabIndex === 0
           ? 0
-          : removedTabIndex === 0
-            ? 0
-            : Math.min(removedTabIndex - 1, this.openRepositoryTabIDs.length - 1)
+          : Math.min(removedTabIndex - 1, this.openRepositoryTabIDs.length - 1)
       const fallbackTabID =
         this.openRepositoryTabIDs.includes(lastSelectedID) &&
         removedTabIndex === null

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -231,6 +231,7 @@ import { promiseWithMinimumTimeout } from '../promise'
 import { BackgroundFetcher } from './helpers/background-fetcher'
 import {
   cleanupOpenRepositoryTabIDs,
+  hasSavedOpenRepositoryTabIDs,
   loadOpenRepositoryTabIDs,
   saveOpenRepositoryTabIDs,
 } from './helpers/open-repository-tabs-storage'
@@ -935,9 +936,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.accountsStore.onDidError(error => this.emitError(error))
 
     this.repositoriesStore.onDidUpdate(updateRepositories => {
+      const selectedTabIndex =
+        this.selectedRepository === null
+          ? -1
+          : this.openRepositoryTabIDs.indexOf(this.selectedRepository.id)
       this.repositories = updateRepositories
       this.cleanupOpenRepositoryTabs(false)
-      this.updateRepositorySelectionAfterRepositoriesChanged()
+      this.updateRepositorySelectionAfterRepositoriesChanged(
+        selectedTabIndex === -1 ? null : selectedTabIndex
+      )
       this.emitUpdate()
     })
 
@@ -2217,19 +2224,37 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.accounts = accounts
     this.repositories = repositories
 
+    const hadSavedRepositoryTabs = hasSavedOpenRepositoryTabIDs()
+    const savedRepositoryTabIDs = loadOpenRepositoryTabIDs()
     this.openRepositoryTabIDs = cleanupOpenRepositoryTabIDs(
-      loadOpenRepositoryTabIDs(),
+      savedRepositoryTabIDs,
       this.repositories
     )
-    if (this.openRepositoryTabIDs.length === 0) {
+
+    if (
+      hadSavedRepositoryTabs &&
+      (savedRepositoryTabIDs.length !== this.openRepositoryTabIDs.length ||
+        savedRepositoryTabIDs.some(
+          (id, index) => this.openRepositoryTabIDs[index] !== id
+        ))
+    ) {
+      saveOpenRepositoryTabIDs(this.openRepositoryTabIDs)
+    }
+
+    if (!hadSavedRepositoryTabs) {
       const lastSelectedID = getNumber(LastSelectedRepositoryIDKey, 0)
-      if (lastSelectedID > 0) {
-        const exists = this.repositories.some(r => r.id === lastSelectedID)
-        if (exists) {
-          this.openRepositoryTabIDs = [lastSelectedID]
-          saveOpenRepositoryTabIDs(this.openRepositoryTabIDs)
-        }
-      }
+      const initialRepository =
+        this.repositories.find(
+          r => r instanceof Repository && r.id === lastSelectedID
+        ) ??
+        this.repositories.find(
+          (r): r is Repository => r instanceof Repository
+        ) ??
+        null
+
+      this.openRepositoryTabIDs =
+        initialRepository === null ? [] : [initialRepository.id]
+      saveOpenRepositoryTabIDs(this.openRepositoryTabIDs)
     }
 
     this.updateRepositorySelectionAfterRepositoriesChanged()
@@ -2651,7 +2676,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
     })
   }
 
-  private updateRepositorySelectionAfterRepositoriesChanged() {
+  private updateRepositorySelectionAfterRepositoriesChanged(
+    removedTabIndex: number | null = null
+  ) {
     const selectedRepository = this.selectedRepository
     let newSelectedRepository: Repository | CloningRepository | null =
       this.selectedRepository
@@ -2666,16 +2693,25 @@ export class AppStore extends TypedBaseStore<IAppState> {
       newSelectedRepository = r
     }
 
-    if (newSelectedRepository === null && this.repositories.length > 0) {
+    if (
+      newSelectedRepository === null &&
+      this.openRepositoryTabIDs.length > 0
+    ) {
       const lastSelectedID = getNumber(LastSelectedRepositoryIDKey, 0)
-      if (lastSelectedID > 0) {
-        newSelectedRepository =
-          this.repositories.find(r => r.id === lastSelectedID) || null
-      }
+      const fallbackTabIndex =
+        removedTabIndex === null
+          ? 0
+          : removedTabIndex === 0
+            ? 0
+            : Math.min(removedTabIndex - 1, this.openRepositoryTabIDs.length - 1)
+      const fallbackTabID =
+        this.openRepositoryTabIDs.includes(lastSelectedID) &&
+        removedTabIndex === null
+          ? lastSelectedID
+          : this.openRepositoryTabIDs[fallbackTabIndex]
 
-      if (!newSelectedRepository) {
-        newSelectedRepository = this.repositories[0]
-      }
+      newSelectedRepository =
+        this.repositories.find(r => r.id === fallbackTabID) ?? null
     }
 
     const repositoryChanged =
@@ -8688,7 +8724,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this.repositories
     )
 
-    if (next.length === this.openRepositoryTabIDs.length) {
+    if (
+      next.length === this.openRepositoryTabIDs.length &&
+      next.every((id, index) => id === this.openRepositoryTabIDs[index])
+    ) {
       return
     }
 
@@ -8817,8 +8856,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     orderedRepositoryIds: ReadonlyArray<number>
   ): Promise<void> {
     const current = new Set(this.openRepositoryTabIDs)
+    const ordered = new Set(orderedRepositoryIds)
     if (
       orderedRepositoryIds.length !== current.size ||
+      ordered.size !== current.size ||
       !orderedRepositoryIds.every(id => current.has(id))
     ) {
       return Promise.resolve()

--- a/app/src/lib/stores/helpers/open-repository-tabs-storage.ts
+++ b/app/src/lib/stores/helpers/open-repository-tabs-storage.ts
@@ -3,6 +3,10 @@ import { Repository } from '../../../models/repository'
 
 export const OpenRepositoryTabsKey = 'open-repository-tab-ids'
 
+export function hasSavedOpenRepositoryTabIDs(): boolean {
+  return localStorage.getItem(OpenRepositoryTabsKey) !== null
+}
+
 export function loadOpenRepositoryTabIDs(): ReadonlyArray<number> {
   return getNumberArray(OpenRepositoryTabsKey)
 }
@@ -18,5 +22,36 @@ export function cleanupOpenRepositoryTabIDs(
   repositories: ReadonlyArray<Repository>
 ): ReadonlyArray<number> {
   const validIds = new Set(repositories.map(r => r.id))
-  return openTabIds.filter(id => validIds.has(id))
+  const seenIds = new Set<number>()
+  return openTabIds.filter(id => {
+    if (!validIds.has(id) || seenIds.has(id)) {
+      return false
+    }
+
+    seenIds.add(id)
+    return true
+  })
+}
+
+export function reorderRepositoryTabIDs(
+  openTabIds: ReadonlyArray<number>,
+  draggedRepositoryId: number,
+  targetRepositoryId: number,
+  position: 'before' | 'after'
+): ReadonlyArray<number> | null {
+  const from = openTabIds.indexOf(draggedRepositoryId)
+  if (
+    from === -1 ||
+    !openTabIds.includes(targetRepositoryId) ||
+    draggedRepositoryId === targetRepositoryId
+  ) {
+    return null
+  }
+
+  const next = [...openTabIds]
+  const [draggedRepository] = next.splice(from, 1)
+  const targetIndex = next.indexOf(targetRepositoryId)
+  const insertionIndex = targetIndex + (position === 'after' ? 1 : 0)
+  next.splice(insertionIndex, 0, draggedRepository)
+  return next
 }

--- a/app/src/ui/repository-tabs/repository-tabs.tsx
+++ b/app/src/ui/repository-tabs/repository-tabs.tsx
@@ -6,6 +6,7 @@ import { Octicon } from '../octicons'
 import * as octicons from '../octicons/octicons.generated'
 import { IMenuItem, showContextualMenu } from '../../lib/menu-item'
 import { FoldoutType } from '../../lib/app-state'
+import { reorderRepositoryTabIDs } from '../../lib/stores/helpers/open-repository-tabs-storage'
 
 const tabDragType = 'application/x-github-desktop-repository-tab'
 
@@ -25,15 +26,86 @@ export class RepositoryTabs extends React.Component<
   IRepositoryTabsProps,
   IRepositoryTabsState
 > {
+  private readonly tabButtonRefs = new Map<number, HTMLButtonElement>()
+  private focusSelectedTabOnUpdate = false
+
   public constructor(props: IRepositoryTabsProps) {
     super(props)
     this.state = { dragOverTabId: null }
   }
 
-  private onTabClick = (repositoryId: number) => {
+  public componentDidUpdate(previousProps: IRepositoryTabsProps) {
+    const selectedRepositoryId = this.props.selectedRepository?.id
+    if (selectedRepositoryId === previousProps.selectedRepository?.id) {
+      return
+    }
+
+    const selectedTab = this.tabButtonRefs.get(selectedRepositoryId ?? -1)
+    selectedTab?.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+
+    if (this.focusSelectedTabOnUpdate) {
+      selectedTab?.focus()
+      this.focusSelectedTabOnUpdate = false
+    }
+  }
+
+  private selectRepositoryTab = (repositoryId: number, focus: boolean) => {
     const repo = this.props.repositories.find(r => r.id === repositoryId)
     if (repo !== undefined) {
+      if (focus && this.props.selectedRepository?.id === repositoryId) {
+        this.tabButtonRefs.get(repositoryId)?.focus()
+        return
+      }
+
+      this.focusSelectedTabOnUpdate = focus
       this.props.dispatcher.selectRepository(repo)
+    }
+  }
+
+  private onTabClick = (repositoryId: number) => {
+    this.selectRepositoryTab(repositoryId, false)
+  }
+
+  private onTabKeyDown = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    repositoryId: number
+  ) => {
+    const tabs = this.props.openRepositoryTabIDs
+    const currentIndex = tabs.indexOf(repositoryId)
+    if (currentIndex === -1) {
+      return
+    }
+
+    let targetIndex: number | null = null
+    if (event.key === 'ArrowLeft') {
+      targetIndex = (currentIndex - 1 + tabs.length) % tabs.length
+    } else if (event.key === 'ArrowRight') {
+      targetIndex = (currentIndex + 1) % tabs.length
+    } else if (event.key === 'Home') {
+      targetIndex = 0
+    } else if (event.key === 'End') {
+      targetIndex = tabs.length - 1
+    } else if (event.key === 'Delete') {
+      this.focusSelectedTabOnUpdate = true
+      this.props.dispatcher.closeRepositoryTab(repositoryId)
+      event.preventDefault()
+      return
+    }
+
+    if (targetIndex !== null) {
+      this.selectRepositoryTab(tabs[targetIndex], true)
+      event.preventDefault()
+    }
+  }
+
+  private onTabButtonRef = (
+    repositoryId: number,
+    button: HTMLButtonElement | null
+  ) => {
+    if (button === null) {
+      this.tabButtonRefs.delete(repositoryId)
+    } else {
+      this.tabButtonRefs.set(repositoryId, button)
     }
   }
 
@@ -107,16 +179,21 @@ export class RepositoryTabs extends React.Component<
         return
       }
 
-      const ids = [...this.props.openRepositoryTabIDs]
-      const from = ids.indexOf(dragId)
-      const to = ids.indexOf(targetRepositoryId)
-      if (from === -1 || to === -1) {
+      const targetBounds = event.currentTarget.getBoundingClientRect()
+      const position =
+        event.clientX < targetBounds.left + targetBounds.width / 2
+          ? 'before'
+          : 'after'
+      const next = reorderRepositoryTabIDs(
+        this.props.openRepositoryTabIDs,
+        dragId,
+        targetRepositoryId,
+        position
+      )
+      if (next === null) {
         return
       }
 
-      const next = [...ids]
-      const [removed] = next.splice(from, 1)
-      next.splice(to, 0, removed)
       void this.props.dispatcher.reorderRepositoryTabs(next)
     }
 
@@ -153,7 +230,7 @@ export class RepositoryTabs extends React.Component<
             const ab = localState?.aheadBehind
             const hasLocalChanges =
               (localState?.changedFilesCount ?? 0) > 0 ||
-              (ab != null && (ab.ahead > 0 || ab.behind > 0))
+              (ab != null && ab.ahead > 0)
 
             const dropHighlight = this.state.dragOverTabId === repositoryId
 
@@ -170,14 +247,19 @@ export class RepositoryTabs extends React.Component<
                 onDrop={this.onTabDrop(repositoryId)}
               >
                 <button
+                  ref={button => this.onTabButtonRef(repositoryId, button)}
                   type="button"
                   className="repository-tab-button"
                   role="tab"
                   aria-selected={selected}
+                  aria-keyshortcuts="Delete"
                   tabIndex={selected ? 0 : -1}
                   draggable
                   onDragStart={this.onTabDragStart(repositoryId)}
                   onClick={() => this.onTabClick(repositoryId)}
+                  onKeyDown={event =>
+                    this.onTabKeyDown(event, repositoryId)
+                  }
                 >
                   {hasLocalChanges ? (
                     <span
@@ -191,6 +273,7 @@ export class RepositoryTabs extends React.Component<
                   type="button"
                   className="repository-tab-close"
                   aria-label={`Close ${title}`}
+                  tabIndex={selected ? 0 : -1}
                   onClick={e => this.onCloseClick(e, repositoryId)}
                 >
                   <Octicon symbol={octicons.x} />

--- a/app/src/ui/repository-tabs/repository-tabs.tsx
+++ b/app/src/ui/repository-tabs/repository-tabs.tsx
@@ -34,9 +34,9 @@ export class RepositoryTabs extends React.Component<
     this.state = { dragOverTabId: null }
   }
 
-  public componentDidUpdate(previousProps: IRepositoryTabsProps) {
+  public componentDidUpdate(prevProps: IRepositoryTabsProps) {
     const selectedRepositoryId = this.props.selectedRepository?.id
-    if (selectedRepositoryId === previousProps.selectedRepository?.id) {
+    if (selectedRepositoryId === prevProps.selectedRepository?.id) {
       return
     }
 
@@ -62,94 +62,86 @@ export class RepositoryTabs extends React.Component<
     }
   }
 
-  private onTabClick = (repositoryId: number) => {
+  private onTabClick = (repositoryId: number) => () =>
     this.selectRepositoryTab(repositoryId, false)
-  }
 
-  private onTabKeyDown = (
-    event: React.KeyboardEvent<HTMLButtonElement>,
-    repositoryId: number
-  ) => {
-    const tabs = this.props.openRepositoryTabIDs
-    const currentIndex = tabs.indexOf(repositoryId)
-    if (currentIndex === -1) {
-      return
+  private onTabKeyDown =
+    (repositoryId: number) =>
+    (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      const tabs = this.props.openRepositoryTabIDs
+      const currentIndex = tabs.indexOf(repositoryId)
+      if (currentIndex === -1) {
+        return
+      }
+
+      let targetIndex: number | null = null
+      if (event.key === 'ArrowLeft') {
+        targetIndex = (currentIndex - 1 + tabs.length) % tabs.length
+      } else if (event.key === 'ArrowRight') {
+        targetIndex = (currentIndex + 1) % tabs.length
+      } else if (event.key === 'Home') {
+        targetIndex = 0
+      } else if (event.key === 'End') {
+        targetIndex = tabs.length - 1
+      } else if (event.key === 'Delete') {
+        this.focusSelectedTabOnUpdate = true
+        this.props.dispatcher.closeRepositoryTab(repositoryId)
+        event.preventDefault()
+        return
+      }
+
+      if (targetIndex !== null) {
+        this.selectRepositoryTab(tabs[targetIndex], true)
+        event.preventDefault()
+      }
     }
 
-    let targetIndex: number | null = null
-    if (event.key === 'ArrowLeft') {
-      targetIndex = (currentIndex - 1 + tabs.length) % tabs.length
-    } else if (event.key === 'ArrowRight') {
-      targetIndex = (currentIndex + 1) % tabs.length
-    } else if (event.key === 'Home') {
-      targetIndex = 0
-    } else if (event.key === 'End') {
-      targetIndex = tabs.length - 1
-    } else if (event.key === 'Delete') {
-      this.focusSelectedTabOnUpdate = true
+  private onTabButtonRef =
+    (repositoryId: number) => (button: HTMLButtonElement | null) => {
+      if (button === null) {
+        this.tabButtonRefs.delete(repositoryId)
+      } else {
+        this.tabButtonRefs.set(repositoryId, button)
+      }
+    }
+
+  private onCloseClick =
+    (repositoryId: number) => (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation()
       this.props.dispatcher.closeRepositoryTab(repositoryId)
-      event.preventDefault()
-      return
     }
-
-    if (targetIndex !== null) {
-      this.selectRepositoryTab(tabs[targetIndex], true)
-      event.preventDefault()
-    }
-  }
-
-  private onTabButtonRef = (
-    repositoryId: number,
-    button: HTMLButtonElement | null
-  ) => {
-    if (button === null) {
-      this.tabButtonRefs.delete(repositoryId)
-    } else {
-      this.tabButtonRefs.set(repositoryId, button)
-    }
-  }
-
-  private onCloseClick = (
-    event: React.MouseEvent<HTMLButtonElement>,
-    repositoryId: number
-  ) => {
-    event.stopPropagation()
-    this.props.dispatcher.closeRepositoryTab(repositoryId)
-  }
 
   private onOpenAnotherRepository = () => {
     this.props.dispatcher.showFoldout({ type: FoldoutType.Repository })
   }
 
-  private onTabContextMenu = (
-    event: React.MouseEvent,
-    repositoryId: number
-  ) => {
-    event.preventDefault()
+  private onTabContextMenu =
+    (repositoryId: number) => (event: React.MouseEvent) => {
+      event.preventDefault()
 
-    const items: ReadonlyArray<IMenuItem> = [
-      {
-        label: 'Close Tab',
-        action: () => {
-          this.props.dispatcher.closeRepositoryTab(repositoryId)
+      const items: ReadonlyArray<IMenuItem> = [
+        {
+          label: 'Close Tab',
+          action: () => {
+            this.props.dispatcher.closeRepositoryTab(repositoryId)
+          },
         },
-      },
-      {
-        label: 'Close Other Tabs',
-        action: () => {
-          this.props.dispatcher.closeOtherRepositoryTabs(repositoryId)
+        {
+          label: 'Close Other Tabs',
+          action: () => {
+            this.props.dispatcher.closeOtherRepositoryTabs(repositoryId)
+          },
         },
-      },
-      {
-        label: 'Close Tabs to the Right',
-        action: () => {
-          this.props.dispatcher.closeRepositoryTabsToRight(repositoryId)
+        {
+          label: 'Close Tabs to the Right',
+          action: () => {
+            this.props.dispatcher.closeRepositoryTabsToRight(repositoryId)
+          },
         },
-      },
-    ]
+      ]
 
-    showContextualMenu(items)
-  }
+      showContextualMenu(items)
+    }
 
   private onTabDragStart =
     (repositoryId: number) => (event: React.DragEvent) => {
@@ -157,17 +149,18 @@ export class RepositoryTabs extends React.Component<
       event.dataTransfer.effectAllowed = 'move'
     }
 
-  private onTabDragOver = (repositoryId: number) => (event: React.DragEvent) => {
-    const types = Array.from(event.dataTransfer.types)
-    if (!types.includes(tabDragType)) {
-      return
+  private onTabDragOver =
+    (repositoryId: number) => (event: React.DragEvent) => {
+      const types = Array.from(event.dataTransfer.types)
+      if (!types.includes(tabDragType)) {
+        return
+      }
+      event.preventDefault()
+      event.dataTransfer.dropEffect = 'move'
+      if (this.state.dragOverTabId !== repositoryId) {
+        this.setState({ dragOverTabId: repositoryId })
+      }
     }
-    event.preventDefault()
-    event.dataTransfer.dropEffect = 'move'
-    if (this.state.dragOverTabId !== repositoryId) {
-      this.setState({ dragOverTabId: repositoryId })
-    }
-  }
 
   private onTabDrop =
     (targetRepositoryId: number) => (event: React.DragEvent) => {
@@ -215,6 +208,7 @@ export class RepositoryTabs extends React.Component<
           className="repository-tabs-scroll"
           role="tablist"
           aria-label="Open repositories"
+          tabIndex={-1}
           onDragEnd={this.onTabStripDragEnd}
         >
           {openRepositoryTabIDs.map(repositoryId => {
@@ -242,30 +236,30 @@ export class RepositoryTabs extends React.Component<
                   'drop-target': dropHighlight,
                 })}
                 role="presentation"
-                onContextMenu={e => this.onTabContextMenu(e, repositoryId)}
+                onContextMenu={this.onTabContextMenu(repositoryId)}
                 onDragOver={this.onTabDragOver(repositoryId)}
                 onDrop={this.onTabDrop(repositoryId)}
               >
                 <button
-                  ref={button => this.onTabButtonRef(repositoryId, button)}
+                  ref={this.onTabButtonRef(repositoryId)}
                   type="button"
                   className="repository-tab-button"
                   role="tab"
                   aria-selected={selected}
+                  aria-label={
+                    hasLocalChanges
+                      ? `${title}, uncommitted or unpushed changes`
+                      : title
+                  }
                   aria-keyshortcuts="Delete"
                   tabIndex={selected ? 0 : -1}
-                  draggable
+                  draggable={true}
                   onDragStart={this.onTabDragStart(repositoryId)}
-                  onClick={() => this.onTabClick(repositoryId)}
-                  onKeyDown={event =>
-                    this.onTabKeyDown(event, repositoryId)
-                  }
+                  onClick={this.onTabClick(repositoryId)}
+                  onKeyDown={this.onTabKeyDown(repositoryId)}
                 >
                   {hasLocalChanges ? (
-                    <span
-                      className="repository-tab-dirty"
-                      title="Uncommitted or unpushed changes"
-                    />
+                    <span className="repository-tab-dirty" />
                   ) : null}
                   <span className="repository-tab-label">{title}</span>
                 </button>
@@ -274,7 +268,7 @@ export class RepositoryTabs extends React.Component<
                   className="repository-tab-close"
                   aria-label={`Close ${title}`}
                   tabIndex={selected ? 0 : -1}
-                  onClick={e => this.onCloseClick(e, repositoryId)}
+                  onClick={this.onCloseClick(repositoryId)}
                 >
                   <Octicon symbol={octicons.x} />
                 </button>
@@ -285,7 +279,6 @@ export class RepositoryTabs extends React.Component<
         <button
           type="button"
           className="repository-tabs-add"
-          title="Open another repository…"
           aria-label="Open another repository"
           onClick={this.onOpenAnotherRepository}
         >

--- a/app/styles/ui/_repository-tabs.scss
+++ b/app/styles/ui/_repository-tabs.scss
@@ -9,9 +9,7 @@
   gap: 2px;
   border-bottom: 1px solid var(--box-border-color);
   background: var(--repository-sidebar-background, var(--box-alt-background-color));
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.04),
-    0 1px 0 rgba(0, 0, 0, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 1px 0 rgba(0, 0, 0, 0.12);
 
   .repository-tabs-scroll {
     display: flex;
@@ -40,10 +38,7 @@
     border-bottom: none;
     border-radius: 8px 8px 0 0;
     background: transparent;
-    transition:
-      background-color 0.15s ease,
-      border-color 0.15s ease,
-      box-shadow 0.15s ease;
+    transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
 
     &:hover:not(.selected) {
       background: var(--list-item-hover-background-color);
@@ -53,9 +48,7 @@
     &.selected {
       background: var(--background-color);
       border-color: var(--box-border-color);
-      box-shadow:
-        0 -1px 0 rgba(0, 0, 0, 0.06),
-        0 1px 2px rgba(0, 0, 0, 0.06);
+      box-shadow: 0 -1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.06);
       z-index: 1;
 
       &::after {
@@ -117,9 +110,7 @@
     background: var(--color-changed);
     margin-right: 8px;
     flex-shrink: 0;
-    box-shadow:
-      0 0 0 1px rgba(0, 0, 0, 0.2),
-      0 0 6px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2), 0 0 6px rgba(0, 0, 0, 0.15);
   }
 
   .repository-tab-close {
@@ -134,9 +125,7 @@
     padding: 0;
     color: var(--text-secondary-color);
     border-radius: 0 7px 0 0;
-    transition:
-      background-color 0.12s ease,
-      color 0.12s ease;
+    transition: background-color 0.12s ease, color 0.12s ease;
 
     &:hover {
       color: var(--text-color);
@@ -170,11 +159,7 @@
     background: var(--box-alt-background-color);
     color: var(--text-secondary-color);
     cursor: pointer;
-    transition:
-      background-color 0.15s ease,
-      color 0.15s ease,
-      border-color 0.15s ease,
-      box-shadow 0.15s ease;
+    transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
 
     &:hover {
       color: var(--text-color);
@@ -196,14 +181,10 @@
 }
 
 body.theme-dark .repository-tabs {
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.04),
-    0 1px 0 rgba(0, 0, 0, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 1px 0 rgba(0, 0, 0, 0.35);
 
   .repository-tab.selected {
-    box-shadow:
-      0 -1px 0 rgba(0, 0, 0, 0.35),
-      0 2px 8px rgba(0, 0, 0, 0.35);
+    box-shadow: 0 -1px 0 rgba(0, 0, 0, 0.35), 0 2px 8px rgba(0, 0, 0, 0.35);
   }
 
   .repository-tabs-add:hover {

--- a/app/styles/ui/_repository-tabs.scss
+++ b/app/styles/ui/_repository-tabs.scss
@@ -143,6 +143,11 @@
       background: var(--list-item-hover-background-color);
     }
 
+    &:focus-visible {
+      outline: 2px solid var(--focus-color);
+      outline-offset: -2px;
+    }
+
     .octicon {
       width: 12px;
       height: 12px;

--- a/app/test/unit/open-repository-tabs-storage-test.ts
+++ b/app/test/unit/open-repository-tabs-storage-test.ts
@@ -36,21 +36,24 @@ describe('open repository tabs storage', () => {
   })
 
   it('reorders a tab before a target to its right', () => {
-    assert.deepEqual(reorderRepositoryTabIDs([1, 2, 3, 4], 1, 3, 'before'), [
-      2, 1, 3, 4,
-    ])
+    assert.deepEqual(
+      reorderRepositoryTabIDs([1, 2, 3, 4], 1, 3, 'before'),
+      [2, 1, 3, 4]
+    )
   })
 
   it('reorders a tab before a target on its left', () => {
-    assert.deepEqual(reorderRepositoryTabIDs([1, 2, 3, 4], 4, 2, 'before'), [
-      1, 4, 2, 3,
-    ])
+    assert.deepEqual(
+      reorderRepositoryTabIDs([1, 2, 3, 4], 4, 2, 'before'),
+      [1, 4, 2, 3]
+    )
   })
 
   it('reorders a tab after a target', () => {
-    assert.deepEqual(reorderRepositoryTabIDs([1, 2, 3, 4], 1, 4, 'after'), [
-      2, 3, 4, 1,
-    ])
+    assert.deepEqual(
+      reorderRepositoryTabIDs([1, 2, 3, 4], 1, 4, 'after'),
+      [2, 3, 4, 1]
+    )
   })
 
   it('does not reorder unknown or identical tabs', () => {

--- a/app/test/unit/open-repository-tabs-storage-test.ts
+++ b/app/test/unit/open-repository-tabs-storage-test.ts
@@ -1,20 +1,60 @@
-import { describe, it } from 'node:test'
+import { beforeEach, describe, it } from 'node:test'
 import assert from 'node:assert'
 import {
   cleanupOpenRepositoryTabIDs,
+  hasSavedOpenRepositoryTabIDs,
   loadOpenRepositoryTabIDs,
+  reorderRepositoryTabIDs,
   saveOpenRepositoryTabIDs,
 } from '../../src/lib/stores/helpers/open-repository-tabs-storage'
 import { Repository } from '../../src/models/repository'
 
 describe('open repository tabs storage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
   it('round-trips tab ids through localStorage', () => {
+    assert.equal(hasSavedOpenRepositoryTabIDs(), false)
     saveOpenRepositoryTabIDs([3, 1, 2])
+    assert.equal(hasSavedOpenRepositoryTabIDs(), true)
     assert.deepEqual(loadOpenRepositoryTabIDs(), [3, 1, 2])
   })
 
-  it('filters tab ids to repositories that still exist', () => {
-    const repos = [new Repository('/a', 1, null, false)]
-    assert.deepEqual(cleanupOpenRepositoryTabIDs([1, 2, 3], repos), [1])
+  it('distinguishes an intentionally empty tab list from missing storage', () => {
+    saveOpenRepositoryTabIDs([])
+    assert.equal(hasSavedOpenRepositoryTabIDs(), true)
+    assert.deepEqual(loadOpenRepositoryTabIDs(), [])
+  })
+
+  it('filters missing and duplicate repository ids', () => {
+    const repos = [
+      new Repository('/a', 1, null, false),
+      new Repository('/b', 2, null, false),
+    ]
+    assert.deepEqual(cleanupOpenRepositoryTabIDs([1, 3, 2, 1], repos), [1, 2])
+  })
+
+  it('reorders a tab before a target to its right', () => {
+    assert.deepEqual(reorderRepositoryTabIDs([1, 2, 3, 4], 1, 3, 'before'), [
+      2, 1, 3, 4,
+    ])
+  })
+
+  it('reorders a tab before a target on its left', () => {
+    assert.deepEqual(reorderRepositoryTabIDs([1, 2, 3, 4], 4, 2, 'before'), [
+      1, 4, 2, 3,
+    ])
+  })
+
+  it('reorders a tab after a target', () => {
+    assert.deepEqual(reorderRepositoryTabIDs([1, 2, 3, 4], 1, 4, 'after'), [
+      2, 3, 4, 1,
+    ])
+  })
+
+  it('does not reorder unknown or identical tabs', () => {
+    assert.equal(reorderRepositoryTabIDs([1, 2], 3, 1, 'before'), null)
+    assert.equal(reorderRepositoryTabIDs([1, 2], 1, 1, 'after'), null)
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
- Preserve intentionally empty tab sets while migrating users without saved tab state
- Select adjacent open tabs when repositories are removed and persist cleaned tab IDs
- Support precise before/after drag placement and reject duplicate reorder payloads
- Add keyboard navigation, focus management, overflow scrolling, accessible labels, and close-button focus styles
- Correct local-change indicators and expand storage/reorder regression coverage

### Screenshots

Not included; these changes correct behavior without changing the overall visual design.

## Testing
- `yarn test:unit app/test/unit/open-repository-tabs-storage-test.ts` (7 passing)
- Targeted ESLint and Prettier checks pass
- Full TypeScript check remains blocked by existing dependency/type setup errors in `re2js`, `desktop-notifications`, IPC types, and duplicate `WeakMap` declarations; no errors reference the changed files

## Release notes

Notes: no-notes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6bcb-239c-73e0-ae0f-350169bb269e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6bcb-239c-73e0-ae0f-350169bb269e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

