### PR TITLE
Add swappable fork update-notify feature (omega-v* releases)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14-xlarge, windows-2022]
+        os: [macos-14, windows-2022]
         arch: [x64, arm64]
         include:
-          - os: macos-14-xlarge
+          - os: macos-14
             friendlyName: macOS
           - os: windows-2022
             friendlyName: Windows
@@ -168,7 +168,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-14-xlarge
+          - os: macos-14
             friendlyName: macOS
             arch: arm64
           - os: windows-2022

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -117,6 +117,17 @@ export function enableAccessibleListToolTips(): boolean {
   return enableBetaFeatures()
 }
 
+/**
+ * [OmegaHawkeye fork] Should the app check the fork's own GitHub Releases
+ * (tags prefixed `omega-v`) and notify the user when a newer fork build is
+ * available? This is the single kill switch for the fork update-notify
+ * feature — flip to `false` (or delete this function together with
+ * app/src/lib/fork-updates/) to fully revert before an upstream merge.
+ */
+export function enableForkUpdates(): boolean {
+  return true
+}
+
 export const enableHooksEnvironment = () => true
 
 export const enableHooksByDefault = enableBetaFeatures

--- a/app/src/lib/fork-updates/fork-config.ts
+++ b/app/src/lib/fork-updates/fork-config.ts
@@ -1,0 +1,38 @@
+/**
+ * [OmegaHawkeye fork] Configuration for the fork update-notify feature.
+ *
+ * This whole folder (`app/src/lib/fork-updates/`) plus the `enableForkUpdates()`
+ * feature flag and one call site in `app.tsx` are the entirety of the feature.
+ * Delete them to revert to stock GitHub Desktop behaviour.
+ */
+
+/**
+ * The fork's own version line, independent from upstream's `release-x.y.z`
+ * numbering. Bump this every time you publish a new `omega-v<semver>` release
+ * so the running build knows what "current" is.
+ *
+ * Keep it a bare SemVer string (no `omega-v` prefix) — the prefix lives only on
+ * the git tags / GitHub releases.
+ */
+export const FORK_CURRENT_VERSION = '1.0.0'
+
+/**
+ * Prefix that distinguishes fork release tags (`omega-v1.2.0`) from upstream's
+ * (`release-3.6.4`). The checker only ever considers tags starting with this,
+ * so upstream tags are ignored and can never trigger a fork update.
+ */
+export const FORK_TAG_PREFIX = 'omega-v'
+
+/** GitHub repository that publishes the fork's releases. */
+export const FORK_REPO_OWNER = 'OmegaHawkeye'
+export const FORK_REPO_NAME = 'github-desktop'
+
+/**
+ * Whether prerelease tags (`omega-v1.2.0-beta.1`) should be offered as updates.
+ * Off by default so testers only see stable fork builds; flip on for a beta
+ * channel.
+ */
+export const FORK_INCLUDE_PRERELEASES = false
+
+/** How often to check for a new fork release while the app is running. */
+export const FORK_UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000 // 6 hours

--- a/app/src/lib/fork-updates/fork-update-checker.ts
+++ b/app/src/lib/fork-updates/fork-update-checker.ts
@@ -1,0 +1,116 @@
+import { Banner, BannerType } from '../../models/banner'
+import { shell } from '../app-shell'
+import { showNotification } from '../notifications/show-notification'
+import {
+  FORK_CURRENT_VERSION,
+  FORK_UPDATE_CHECK_INTERVAL_MS,
+} from './fork-config'
+import { GitHubReleasesProvider } from './github-releases-provider'
+import { IForkUpdate, IForkUpdateProvider } from './types'
+
+/** localStorage key recording the last fork version we sent an OS toast for. */
+const lastNotifiedForkVersionKey = 'last-notified-fork-version'
+
+/**
+ * Minimal slice of the Dispatcher the checker needs, so this lib module doesn't
+ * depend on the whole UI dispatcher.
+ */
+interface IBannerDispatcher {
+  setBanner(banner: Banner): void
+}
+
+/**
+ * [OmegaHawkeye fork] Periodically asks an {@link IForkUpdateProvider} whether a
+ * newer fork build exists and, when one does, surfaces it two ways:
+ *
+ *  A. an in-app banner (persistent until dismissed), and
+ *  B. a native OS toast (fired once per new version, even if unfocused).
+ *
+ * Swap the provider below to change where updates come from.
+ */
+class ForkUpdateChecker {
+  private readonly provider: IForkUpdateProvider = new GitHubReleasesProvider()
+  private intervalHandle: number | null = null
+  private dispatcher: IBannerDispatcher | null = null
+
+  /** Version we've already raised the banner for this session (dedupe). */
+  private bannerShownForVersion: string | null = null
+
+  /**
+   * Begin checking: once immediately, then on an interval. Safe to call once at
+   * app startup. No-op if already started.
+   */
+  public start(dispatcher: IBannerDispatcher) {
+    if (this.intervalHandle !== null) {
+      return
+    }
+
+    this.dispatcher = dispatcher
+    this.check()
+    this.intervalHandle = window.setInterval(
+      () => this.check(),
+      FORK_UPDATE_CHECK_INTERVAL_MS
+    )
+  }
+
+  public stop() {
+    if (this.intervalHandle !== null) {
+      window.clearInterval(this.intervalHandle)
+      this.intervalHandle = null
+    }
+  }
+
+  /** Run a single check now (also used by a manual "Check for updates"). */
+  public async check() {
+    try {
+      const update = await this.provider.checkForUpdate(FORK_CURRENT_VERSION)
+      if (update === null) {
+        return
+      }
+      this.showBanner(update)
+      this.maybeShowNotification(update)
+    } catch (e) {
+      log.warn('[fork-updates] check failed', e)
+    }
+  }
+
+  // Surface A — in-app banner. Shown once per version so we don't re-raise a
+  // banner the user has dismissed on every interval tick.
+  private showBanner(update: IForkUpdate) {
+    if (this.dispatcher === null) {
+      return
+    }
+    if (this.bannerShownForVersion === update.version.raw) {
+      return
+    }
+    this.bannerShownForVersion = update.version.raw
+
+    this.dispatcher.setBanner({
+      type: BannerType.ForkUpdateAvailable,
+      releaseName: update.name,
+      notesUrl: update.notesUrl,
+      downloadUrl: update.downloadUrl,
+    })
+  }
+
+  // Surface B — native OS toast. Fired at most once per version, ever
+  // (persisted), so restarting the app doesn't re-toast the same release.
+  private maybeShowNotification(update: IForkUpdate) {
+    const alreadyNotified = localStorage.getItem(lastNotifiedForkVersionKey)
+    if (alreadyNotified === update.version.raw) {
+      return
+    }
+    localStorage.setItem(lastNotifiedForkVersionKey, update.version.raw)
+
+    showNotification({
+      title: 'Update available',
+      body: `${update.name} is available. Click to see what's new and download.`,
+      onClick: () => {
+        shell.openExternal(update.downloadUrl ?? update.notesUrl)
+      },
+    })
+  }
+}
+
+/** [OmegaHawkeye fork] Singleton fork update checker. */
+export const forkUpdateChecker = new ForkUpdateChecker()

--- a/app/src/lib/fork-updates/github-releases-provider.ts
+++ b/app/src/lib/fork-updates/github-releases-provider.ts
@@ -1,0 +1,134 @@
+import { gt, SemVer, valid } from 'semver'
+import { getUserAgent } from '../http'
+import { IForkUpdate, IForkUpdateProvider } from './types'
+import {
+  FORK_INCLUDE_PRERELEASES,
+  FORK_REPO_NAME,
+  FORK_REPO_OWNER,
+  FORK_TAG_PREFIX,
+} from './fork-config'
+
+/** Shape of the bits of the GitHub Releases API response we consume. */
+interface IGitHubRelease {
+  readonly tag_name: string
+  readonly name: string | null
+  readonly html_url: string
+  readonly draft: boolean
+  readonly prerelease: boolean
+  readonly published_at: string | null
+  readonly assets: ReadonlyArray<{
+    readonly name: string
+    readonly browser_download_url: string
+  }>
+}
+
+/**
+ * [OmegaHawkeye fork] Reads the fork's own GitHub Releases and reports the
+ * newest one that is a valid `omega-v<semver>` tag newer than the running
+ * build. This is the concrete {@link IForkUpdateProvider} in use today.
+ */
+export class GitHubReleasesProvider implements IForkUpdateProvider {
+  public async checkForUpdate(
+    currentVersion: string
+  ): Promise<IForkUpdate | null> {
+    const current = valid(currentVersion)
+    if (current === null) {
+      log.error(
+        `[fork-updates] current fork version "${currentVersion}" is not valid semver; skipping check`
+      )
+      return null
+    }
+
+    const releases = await this.fetchReleases()
+    if (releases === null) {
+      return null
+    }
+
+    let best: IForkUpdate | null = null
+    for (const release of releases) {
+      const candidate = this.parseRelease(release)
+      if (candidate === null) {
+        continue
+      }
+      if (best === null || gt(candidate.version, best.version)) {
+        best = candidate
+      }
+    }
+
+    if (best === null) {
+      return null
+    }
+
+    return gt(best.version, new SemVer(current)) ? best : null
+  }
+
+  private async fetchReleases(): Promise<ReadonlyArray<IGitHubRelease> | null> {
+    const url = `https://api.github.com/repos/${FORK_REPO_OWNER}/${FORK_REPO_NAME}/releases?per_page=100`
+
+    try {
+      const response = await fetch(url, {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          'User-Agent': getUserAgent(),
+        },
+      })
+
+      if (!response.ok) {
+        log.warn(
+          `[fork-updates] releases request failed: ${response.status} ${response.statusText}`
+        )
+        return null
+      }
+
+      return (await response.json()) as ReadonlyArray<IGitHubRelease>
+    } catch (e) {
+      log.warn('[fork-updates] error fetching releases', e)
+      return null
+    }
+  }
+
+  /** Turn a raw release into an {@link IForkUpdate}, or `null` if it should be ignored. */
+  private parseRelease(release: IGitHubRelease): IForkUpdate | null {
+    if (release.draft) {
+      return null
+    }
+    if (release.prerelease && !FORK_INCLUDE_PRERELEASES) {
+      return null
+    }
+    if (!release.tag_name.startsWith(FORK_TAG_PREFIX)) {
+      return null
+    }
+
+    const rawVersion = release.tag_name.slice(FORK_TAG_PREFIX.length)
+    if (valid(rawVersion) === null) {
+      return null
+    }
+
+    return {
+      version: new SemVer(rawVersion),
+      tag: release.tag_name,
+      name: release.name ?? release.tag_name,
+      notesUrl: release.html_url,
+      downloadUrl: this.pickAssetUrl(release) ?? release.html_url,
+      publishedAt: release.published_at
+        ? new Date(release.published_at)
+        : new Date(0),
+      isPrerelease: release.prerelease,
+    }
+  }
+
+  /** Match a downloadable asset for the current platform, if any. */
+  private pickAssetUrl(release: IGitHubRelease): string | null {
+    const extensions = __WIN32__
+      ? ['.exe', '.msi']
+      : __DARWIN__
+      ? ['.dmg', '.zip']
+      : ['.appimage', '.deb', '.rpm']
+
+    const match = release.assets.find(a =>
+      extensions.some(ext => a.name.toLowerCase().endsWith(ext))
+    )
+
+    return match?.browser_download_url ?? null
+  }
+}

--- a/app/src/lib/fork-updates/index.ts
+++ b/app/src/lib/fork-updates/index.ts
@@ -1,0 +1,6 @@
+/**
+ * [OmegaHawkeye fork] Public surface of the fork update-notify feature.
+ * See fork-config.ts for the knobs and the swap seam (IForkUpdateProvider).
+ */
+export { forkUpdateChecker } from './fork-update-checker'
+export type { IForkUpdate, IForkUpdateProvider } from './types'

--- a/app/src/lib/fork-updates/types.ts
+++ b/app/src/lib/fork-updates/types.ts
@@ -1,0 +1,43 @@
+import { SemVer } from 'semver'
+
+/**
+ * [OmegaHawkeye fork] A newer fork release than the one currently running.
+ * Returned by an {@link IForkUpdateProvider} when an update is available.
+ */
+export interface IForkUpdate {
+  /** Parsed fork version, e.g. SemVer of `1.2.0` from tag `omega-v1.2.0`. */
+  readonly version: SemVer
+  /** The raw git tag, e.g. `omega-v1.2.0`. */
+  readonly tag: string
+  /** Human-readable release name/title. */
+  readonly name: string
+  /** URL of the release page (shown via "What's new"). */
+  readonly notesUrl: string
+  /**
+   * Direct download URL for a matching per-platform asset, or `null` if no
+   * asset matched (in which case consumers fall back to `notesUrl`).
+   */
+  readonly downloadUrl: string | null
+  /** When the release was published. */
+  readonly publishedAt: Date
+  /** Whether this is a prerelease (`omega-v1.2.0-beta.1`). */
+  readonly isPrerelease: boolean
+}
+
+/**
+ * [OmegaHawkeye fork] The swap seam. A source of fork update information.
+ *
+ * `GitHubReleasesProvider` is the only implementation today; to move off GitHub
+ * (Gitea, S3-hosted JSON, a private endpoint…) write another class that
+ * satisfies this interface and swap it in `fork-update-checker.ts` — nothing
+ * else in the app changes.
+ */
+export interface IForkUpdateProvider {
+  /**
+   * Resolve the newest available fork release.
+   *
+   * @param currentVersion The running build's fork version (bare SemVer).
+   * @returns The update if a newer release exists, otherwise `null`.
+   */
+  checkForUpdate(currentVersion: string): Promise<IForkUpdate | null>
+}

--- a/app/src/models/banner.ts
+++ b/app/src/models/banner.ts
@@ -17,6 +17,8 @@ export enum BannerType {
   SuccessfulReorder = 'SuccessfulReorder',
   ConflictsFound = 'ConflictsFound',
   OSVersionNoLongerSupported = 'OSVersionNoLongerSupported',
+  // [OmegaHawkeye fork] update-notify feature — remove with app/src/lib/fork-updates/
+  ForkUpdateAvailable = 'ForkUpdateAvailable',
 }
 
 export type Banner =
@@ -122,3 +124,13 @@ export type Banner =
       readonly onOpenConflictsDialog: () => void
     }
   | { readonly type: BannerType.OSVersionNoLongerSupported }
+  // [OmegaHawkeye fork] A newer fork build (omega-v*) is available to download.
+  | {
+      readonly type: BannerType.ForkUpdateAvailable
+      /** Release title, e.g. `omega-v1.2.0`. */
+      readonly releaseName: string
+      /** URL of the release page ("What's new"). */
+      readonly notesUrl: string
+      /** Direct asset download URL, or `null` to fall back to notesUrl. */
+      readonly downloadUrl: string | null
+    }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -15,6 +15,8 @@ import { AppStore, GitHubUserStore, IssuesStore } from '../lib/stores'
 import { assertNever } from '../lib/fatal-error'
 import { shell } from '../lib/app-shell'
 import { updateStore, UpdateStatus } from './lib/update-store'
+// [OmegaHawkeye fork] update-notify feature — remove with app/src/lib/fork-updates/
+import { forkUpdateChecker } from '../lib/fork-updates'
 import { RetryAction } from '../models/retry-actions'
 import { FetchType } from '../models/fetch'
 import { shouldRenderApplicationMenu } from './lib/features'
@@ -200,6 +202,7 @@ import { TestCLIActionDialog } from './cli-action/test-cli-action-dialog'
 import { TestCopilotSnapshotCardDialog } from './preferences/test-copilot-snapshot-card-dialog'
 import {
   enableCopilotSdkCommitMessageGeneration,
+  enableForkUpdates,
   enableWorktreeSupport,
 } from '../lib/feature-flag'
 import {
@@ -403,6 +406,13 @@ export class App extends React.Component<IAppProps, IAppState> {
       // env. Prod and beta environment will trigger this during automatic check
       // for updates.
       this.props.dispatcher.setUpdateShowCaseVisibility(true)
+    }
+
+    // [OmegaHawkeye fork] Check the fork's own GitHub Releases (omega-v*) and
+    // notify via banner + OS toast. Runs on all channels. Remove this block
+    // together with app/src/lib/fork-updates/ to revert.
+    if (enableForkUpdates()) {
+      forkUpdateChecker.start(this.props.dispatcher)
     }
 
     log.info(`launching: ${getVersion()} (${getOS()})`)

--- a/app/src/ui/banners/fork-update-available.tsx
+++ b/app/src/ui/banners/fork-update-available.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react'
+import { Octicon } from '../octicons'
+import * as octicons from '../octicons/octicons.generated'
+import { Banner } from './banner'
+import { LinkButton } from '../lib/link-button'
+import { shell } from '../../lib/app-shell'
+
+interface IForkUpdateAvailableProps {
+  /** Release title, e.g. `omega-v1.2.0`. */
+  readonly releaseName: string
+  /** URL of the release page ("What's new"). */
+  readonly notesUrl: string
+  /** Direct asset download URL, or `null` to fall back to notesUrl. */
+  readonly downloadUrl: string | null
+  readonly onDismissed: () => void
+}
+
+/**
+ * [OmegaHawkeye fork] In-app banner (surface A) telling the user a newer fork
+ * build is available. Notify-only: buttons open the fork's GitHub release page /
+ * download asset in the browser — this does not silently swap the binary.
+ */
+export class ForkUpdateAvailable extends React.Component<IForkUpdateAvailableProps> {
+  private onDownload = () => {
+    shell.openExternal(this.props.downloadUrl ?? this.props.notesUrl)
+  }
+
+  public render() {
+    return (
+      <Banner
+        id="fork-update-available"
+        className="fork-update-banner"
+        dismissable={true}
+        onDismissed={this.props.onDismissed}
+      >
+        <span className="fork-update-badge" aria-hidden={true}>
+          <Octicon symbol={octicons.desktopDownload} />
+        </span>
+        <span className="fork-update-message">
+          New version available: {this.props.releaseName}
+        </span>
+        <LinkButton
+          className="fork-update-action ghost"
+          uri={this.props.notesUrl}
+        >
+          What's new
+        </LinkButton>
+        <LinkButton
+          className="fork-update-action primary"
+          onClick={this.onDownload}
+        >
+          Download
+        </LinkButton>
+      </Banner>
+    )
+  }
+}

--- a/app/src/ui/banners/render-banner.tsx
+++ b/app/src/ui/banners/render-banner.tsx
@@ -19,6 +19,8 @@ import { SuccessfulSquash } from './successful-squash'
 import { SuccessBanner } from './success-banner'
 import { ConflictsFoundBanner } from './conflicts-found-banner'
 import { OSVersionNoLongerSupportedBanner } from './os-version-no-longer-supported-banner'
+// [OmegaHawkeye fork] update-notify feature — remove with app/src/lib/fork-updates/
+import { ForkUpdateAvailable } from './fork-update-available'
 
 export function renderBanner(
   banner: Banner,
@@ -171,6 +173,17 @@ export function renderBanner(
       )
     case BannerType.OSVersionNoLongerSupported:
       return <OSVersionNoLongerSupportedBanner onDismissed={onDismissed} />
+    // [OmegaHawkeye fork] update-notify feature — remove with app/src/lib/fork-updates/
+    case BannerType.ForkUpdateAvailable:
+      return (
+        <ForkUpdateAvailable
+          key="fork-update-available"
+          releaseName={banner.releaseName}
+          notesUrl={banner.notesUrl}
+          downloadUrl={banner.downloadUrl}
+          onDismissed={onDismissed}
+        />
+      )
     default:
       return assertNever(banner, `Unknown popup type: ${banner}`)
   }

--- a/app/styles/ui/_banners.scss
+++ b/app/styles/ui/_banners.scss
@@ -3,6 +3,8 @@
 @import 'banners/update-available';
 @import 'banners/open_thank_you_card';
 @import 'banners/os-not-supported';
+// [OmegaHawkeye fork] remove with app/src/lib/fork-updates/
+@import 'banners/fork-update';
 
 .banner {
   $banner-height: 30px;

--- a/app/styles/ui/banners/_fork-update.scss
+++ b/app/styles/ui/banners/_fork-update.scss
@@ -1,0 +1,110 @@
+// [OmegaHawkeye fork] Styling for the fork update-notify banner (surface A).
+// A modern solid-blue bar with a circular icon badge, concise message, and two
+// pill actions (ghost "What's new" + solid "Download"). Remove together with
+// app/src/lib/fork-updates/.
+#fork-update-available.fork-update-banner {
+  $fork-banner-height: 46px;
+  $fork-banner-blue: #1f6feb;
+
+  height: $fork-banner-height;
+  padding-left: var(--spacing);
+  background-color: $fork-banner-blue;
+  color: #ffffff;
+
+  // Let the contents span the width so the message can push the actions right.
+  .contents {
+    flex: 1;
+    min-width: 0;
+  }
+
+  // Circular translucent badge around the icon.
+  .fork-update-badge {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    margin-right: var(--spacing-half);
+    border-radius: 50%;
+    background-color: rgba(255, 255, 255, 0.2);
+    color: #ffffff;
+
+    .octicon {
+      width: 14px;
+      height: 14px;
+      fill: currentColor;
+    }
+  }
+
+  // Message text; `margin-right: auto` pushes the actions to the right edge.
+  .fork-update-message {
+    margin-right: auto;
+    padding-right: var(--spacing);
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  // Shared pill styling for both action links.
+  .fork-update-action {
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    height: 26px;
+    margin-left: var(--spacing-half);
+    padding: 0 12px;
+    border-radius: 6px;
+    font-weight: 500;
+    text-decoration: none;
+    white-space: nowrap;
+
+    &:hover,
+    &:focus {
+      text-decoration: none;
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(255, 255, 255, 0.85);
+      outline-offset: 1px;
+    }
+
+    // Ghost pill — translucent white on blue.
+    &.ghost {
+      color: #ffffff;
+      background-color: rgba(255, 255, 255, 0.18);
+
+      &:hover {
+        color: #ffffff;
+        background-color: rgba(255, 255, 255, 0.28);
+      }
+    }
+
+    // Primary pill — solid white with blue text.
+    &.primary {
+      color: $fork-banner-blue;
+      background-color: #ffffff;
+      font-weight: 600;
+
+      &:hover {
+        color: $fork-banner-blue;
+        background-color: #f2f6fc;
+      }
+    }
+  }
+
+  // The wrapper's dismiss (×) button, tinted for the blue background.
+  .close button {
+    color: rgba(255, 255, 255, 0.85);
+
+    &:hover {
+      color: #ffffff;
+    }
+  }
+
+  // Keep the taller height through the enter/exit transitions.
+  &.banner-enter.banner-enter-active,
+  &.banner-exit {
+    height: $fork-banner-height;
+  }
+}


### PR DESCRIPTION
## What

Adds a **notify-only** self-update feature for the fork: it watches this repo's own **GitHub Releases** (tags prefixed `omega-v`) and tells the user when a newer fork build is available — via an in-app banner **and** a native OS toast. Both open the release page / download asset in the browser; it does **not** silently swap the binary and never touches the official Squirrel auto-update path.

## Tag convention

Fork releases use `omega-v<semver>` (e.g. `omega-v1.0.0`, `omega-v1.1.0-beta.1`). The `omega-v` prefix can never collide with upstream's `release-<semver>` tags, and strips cleanly to valid SemVer for comparison. Independent version line starting at `1.0.0`.

## Design — built to be removed

Everything is gated by `enableForkUpdates()` and isolated in `app/src/lib/fork-updates/`:

- `fork-config.ts` — knobs: `FORK_CURRENT_VERSION` (bump per release), tag prefix, repo, prerelease toggle, interval.
- `types.ts` — `IForkUpdateProvider` (the swap seam) + `IForkUpdate`.
- `github-releases-provider.ts` — the one implementation; hits the GitHub Releases API, filters `omega-v*`, picks the highest newer SemVer, matches a per-platform asset.
- `fork-update-checker.ts` — timer + dedupe; fires the banner (once/version) and OS toast (once/version, persisted).

Wired at a single call site in `app.tsx`. To revert before merging fork features upstream: delete the folder + the flag + the tagged hunks in 5 files. Diff against the upstream update system is zero.

## Verification

- `tsc --noEmit` — no errors in `app/src`.
- `eslint` + `prettier` — clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)